### PR TITLE
[web-6601] - Modify imgs to an almost black color.

### DIFF
--- a/style.css
+++ b/style.css
@@ -5630,6 +5630,10 @@ main.main-sidebar {
   font-size: 1.5em;
 }
 
+.almost-black-img {
+  filter: invert(24%) sepia(21%) saturate(0%) hue-rotate(219deg) brightness(99%) contrast(95%);
+}
+
 .black-icon {
   color: var(--color-almost-black);
   color: #424242;

--- a/styles/_custom.scss
+++ b/styles/_custom.scss
@@ -1383,6 +1383,10 @@ main.main-sidebar {
   }
 }
 
+.almost-black-img {
+  filter: invert(24%) sepia(21%) saturate(0%) hue-rotate(219deg) brightness(99%) contrast(95%);
+}
+
 .black-icon {
   color: var(--color-almost-black);
   color: #424242;

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -61,25 +61,25 @@
 							<i class="material-icons black-icon">keyboard</i>
 							{{else}}
 							{{#is id 360006341474}} {{!-- Products --}}
-							<img class="material-icons black-icon" src="{{asset 'single_bed-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'single_bed-24px.svg'}}" />
 							{{else}}
 							{{#is id 360006341054}} {{!-- Data Import --}}
 							<i class="material-icons black-icon">arrow_downward</i>
 							{{else}}
 							{{#is id 360006367853}} {{!-- Validation --}}
-							<img class="material-icons black-icon" src="{{asset 'done_outline-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'done_outline-24px.svg'}}" />
 							{{else}}
 							{{#is id 360006367813}} {{!-- Product Catalogues --}}
 							<i class="material-icons black-icon">extension</i>
 							{{else}}
 							{{#is id 360006367793}} {{!-- Geometry --}}
-							<img class="material-icons black-icon" src="{{asset 'square_foot-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'square_foot-24px.svg'}}" />
 							{{else}}
 							{{#is id 360006367773}} {{!-- Data Catalogues --}}
 							<i class="material-icons black-icon">code</i>
 							{{else}}
 							{{#is id 360006340154}} {{!-- Utilities --}}
-							<img class="material-icons black-icon" src="{{asset 'speed-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'speed-24px.svg'}}" />
 							{{else}}
 							{{#is id 360006340134}} {{!-- Model Lab --}}
 							<i class="material-icons black-icon">invert_colors</i>
@@ -94,7 +94,7 @@
 							<i class="material-icons black-icon">power_settings_new</i>
 							{{else}}
 							{{#is id 360005905054}} {{!--  License Administration --}}
-							<img class="material-icons black-icon" src="{{asset 'how_to_reg-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'how_to_reg-24px.svg'}}" />
 							{{else}}
 							{{#is id 360005516633}} {{!--  License Extension Management  --}}
 							<i class="material-icons black-icon">build</i>
@@ -109,10 +109,10 @@
 							<i class="material-icons black-icon">cloud_upload</i>
 							{{else}}
 							{{#is id 360009205154}} {{!-- Catalogue Stretch --}}
-							<img class="material-icons black-icon" src="{{asset 'open_in_full-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'open_in_full-24px.svg'}}" />
 							{{else}}
 							{{#is id 360009464453}} {{!-- Scheme Builder --}}
-							<img class="material-icons black-icon" src="{{asset 'construction-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'construction-24px.svg'}}" />
 							{{else}}
 							{{#is id 360010571634}} {{!-- Release Testing --}}
 							<i class="material-icons black-icon">assignment_turned_in</i>
@@ -124,22 +124,22 @@
 							<i class="material-icons black-icon">filter_tilt_shift</i>
 							{{else}}
 							{{#is id 360009868114}}
-							<img class="material-icons black-icon" src="{{asset 'abstract_implementations-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'abstract_implementations-24px.svg'}}" />
 							{{else}}
 							{{#is id 360008682454}}
-							<img class="material-icons black-icon" src="{{asset 'handyman-24px.svg'}}"/>
+							<img class="material-icons almost-black-img" src="{{asset 'handyman-24px.svg'}}"/>
 							{{else}}
 							{{#is id 360010974793}}
 							<i class="material-icons black-icon">import_contacts</i>
 							{{else}}
 							{{#is id 360009074214}}
-							<img class="material-icons black-icon" src="{{asset 'schema-24px.svg'}}"/>
+							<img class="material-icons almost-black-img" src="{{asset 'schema-24px.svg'}}"/>
 							{{else}}
 							{{#is id 360009868154}}
 							<i class="material-icons black-icon">publish</i>
 							{{else}}
 							{{#is id 360009868174}}
-							<img class="material-icons black-icon" src="{{asset 'quality_assurance-24px.svg'}}" />
+							<img class="material-icons almost-black-img" src="{{asset 'quality_assurance-24px.svg'}}" />
 							{{else}}
 							<i class="material-icons black-icon">camera</i>
 							{{/is}}

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -24,13 +24,13 @@
       <a href="{{url}}" class="custom-card-link">
         <div class="custom-card-logo-container">
           {{#is id 360009733874}}
-          <img class="material-icons black-icon" src="{{asset 'rule-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'rule-24px.svg'}}" />
           {{else}}
           {{#is id 360010838733}}
           <i class="material-icons black-icon">storage</i>
           {{else}}
           {{#is id 360009734414}}
-          <img class="material-icons black-icon" src="{{asset 'text_snippet-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'text_snippet-24px.svg'}}" />
           {{else}}
           {{#is id 360009734354}}
           <i class="material-icons black-icon">low_priority</i>
@@ -42,10 +42,10 @@
           <i class="material-icons black-icon">developer_mode</i>
           {{else}}
           {{#is id 360010838853}}
-          <img class="material-icons black-icon" src="{{asset 'api-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'api-24px.svg'}}" />
           {{else}}
           {{#is id 360010838833}}
-          <img class="material-icons black-icon" src="{{asset 'grading-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'grading-24px.svg'}}" />
           {{else}}
           {{#is id 360010839453}}
           <i class="material-icons black-icon">more_horiz</i>
@@ -57,16 +57,16 @@
           <i class="material-icons black-icon">event_seat</i>
           {{else}}
           {{#is id 360010840153}}
-          <img class="material-icons black-icon" src="{{asset 'close_fullscreen-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'close_fullscreen-24px.svg'}}" />
           {{else}}
           {{#is id 360010840253}}
           <i class="material-icons black-icon">settings_input_component</i>
           {{else}}
           {{#is id 360009735934}}
-          <img class="material-icons black-icon" src="{{asset 'category-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'category-24px.svg'}}" />
           {{else}}
           {{#is id 360009735954}}
-          <img class="material-icons black-icon" src="{{asset 'list_alt-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'list_alt-24px.svg'}}" />
           {{else}}
           {{#is id 360009735974}}
           <i class="material-icons black-icon">filter_hdr</i>
@@ -78,7 +78,7 @@
           <i class="material-icons black-icon">undo</i>
           {{else}}
           {{#is id 360010840333}}
-          <img class="material-icons black-icon" src="{{asset 'wysiwyg-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'wysiwyg-24px.svg'}}" />
           {{else}}
           {{#is id 360010840353}}
           <i class="material-icons black-icon">wb_incandescent</i>
@@ -93,25 +93,25 @@
           <i class="material-icons black-icon">weekend</i>
           {{else}}
           {{#is id 360009868234}}
-          <img class="material-icons black-icon" src="{{asset 'engineering-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'engineering-24px.svg'}}" />
           {{else}}
           {{#is id 360009868254}}
-          <img class="material-icons black-icon" src="{{asset 'hvac-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'hvac-24px.svg'}}" />
           {{else}}
           {{#is id 360009868274}}
-          <img class="material-icons black-icon" src="{{asset 'revit-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'revit-24px.svg'}}" />
           {{else}}
           {{#is id 360010974853}}
           <i class="material-icons black-icon">more_horiz</i>
           {{else}}
           {{#is id 360009074194}}
-          <img class="material-icons black-icon" src="{{asset 'cet_developer-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'cet_developer-24px.svg'}}" />
           {{else}}
           {{#is id 360009074174}}
-          <img class="material-icons black-icon" src="{{asset 'emacs-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'emacs-24px.svg'}}" />
           {{else}}
           {{#is id 360009193473}}
-          <img class="material-icons black-icon" src="{{asset 'cet_designer-24px.svg'}}" />
+          <img class="material-icons almost-black-img" src="{{asset 'cet_designer-24px.svg'}}" />
           {{else}}
           {{#is id 360009868314}}
           <i class="material-icons black-icon">assignment</i>


### PR DESCRIPTION
Some material icons are svg files and this branch uses the css filter property to change their colors to an almost black. This does not work on IE though.